### PR TITLE
Fix transcript hash definition

### DIFF
--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -852,7 +852,7 @@ hash with the (attested) identity key, and sends the attestation
 evidence and the signature in the Certificate and the CertificateVerify
 messages respectively. The transcript hash, denoted `hs` in the figure
 below, follows the `Transcript-Hash` definition from {{Section 4.4 of
-!RFC8446}}.
+-tls13}}.
 
 The client forwards the attestation evidence to the verifier using the
 previously established session, obtains the attestation result (AR) and

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -848,10 +848,11 @@ in the specular extension and proceed by invoking a local API
 attestation using the nonce supplied by the verifier.  The returned
 evidence binds the identity key (TIK-S) with the platform identity and
 security state, packaged into a CAB.  The server then signs a transcript
-hash (represented by `hs` in the figure below) of the handshake context
-and the server's Certificate message with the (attested) identity key,
-and sends the attestation evidence together with the signature over to
-the client.
+hash with the (attested) identity key, and sends the attestation
+evidence and the signature in the Certificate and the CertificateVerify
+messages respectively. The transcript hash, denoted `hs` in the figure
+below, follows the `Transcript-Hash` definition from {{Section 4.4 of
+!RFC8446}}.
 
 The client forwards the attestation evidence to the verifier using the
 previously established session, obtains the attestation result (AR) and

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -851,7 +851,7 @@ security state, packaged into a CAB.  The server then signs a transcript
 hash with the (attested) identity key, and sends the attestation
 evidence and the signature in the Certificate and the CertificateVerify
 messages respectively. The transcript hash, denoted `hs` in the figure
-below, follows the `Transcript-Hash` definition from {{Section 4.4 of
+below, follows the `Transcript-Hash` definition from {{Section 4.4.1 of
 -tls13}}.
 
 The client forwards the attestation evidence to the verifier using the


### PR DESCRIPTION
As per the request in #23, making `hs` clearer.